### PR TITLE
When generating tasks, only process emails not assigned a task already.

### DIFF
--- a/app/Services/Task/ProcessTasksService.php
+++ b/app/Services/Task/ProcessTasksService.php
@@ -34,7 +34,7 @@ class ProcessTasksService
      */
     public function run(User $user)
     {
-        $emails = $user->emails()->processed()->categorized()->get();
+        $emails = $user->emails()->processed()->categorized()->withNoTask()->get();
 
         if ($emails->count() === 0) {
             return NoTasksToGenerate::broadcast();


### PR DESCRIPTION
- When generating tasks, only process emails not assigned a task already.